### PR TITLE
Relax depdencny requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,21 +32,21 @@ classifiers=[
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "click>=8.1.8,<9",
-  "fsspec>=2021.09.0,<2026",
-  "dask>=2024.8.0,<2026",
-  "h5py>=3.13.0,<4",
-  "h5pyd>=0.18.0,<1",
-  "numpy>=2.0.2,<3",
-  "pandas>=2.2.3,<3",
-  "packaging>=24.2,<25",
-  "psutil>=7.0.0,<8",
-  "PyYAML>=6.0.2,<7",
-  "s3fs>=2023.6.0,<2026",
-  "scikit-learn>=1.6.1,<2",
-  "scipy>=1.3,<2",
-  "toml>=0.10.2,<0.11",
-  "xarray>=2024.07.0,<2026",
+  "click>=8.1.8",
+  "fsspec>=2021.09.0",
+  "dask>=2024.8.0",
+  "h5py>=3.13.0",
+  "h5pyd>=0.18.0",
+  "numpy>=2.0.2",
+  "pandas>=2.2.3",
+  "packaging>=24.2",
+  "psutil>=7.0.0",
+  "PyYAML>=6.0.2",
+  "s3fs>=2023.6.0",
+  "scikit-learn>=1.6.1",
+  "scipy>=1.3",
+  "toml>=0.10.2",
+  "xarray>=2024.07.0",
 ]
 
 [project.optional-dependencies]
@@ -61,7 +61,7 @@ dev = [
   "pylint",
 ]
 hsds = [
-  "hsds>=0.8.4,<1",
+  "hsds>=0.8.4",
 ]
 build = [
   "build>=1.2.2,<2",

--- a/rex/version.py
+++ b/rex/version.py
@@ -1,3 +1,3 @@
 """rex Version number"""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
Since `rex` is meant to frequently be used in downstream libraries, we should relax the upper bound on dependencies to make it more compatible. The tradeoff is that it puts more onus on downstream users to test functionality, but good faith actors should be writing tests anyways so this is overall more flexible for end users.